### PR TITLE
Fix first Eattempt EL / AMZ checkout not spliting carts

### DIFF
--- a/wp-content/plugins/woo-multistep-checkout/templates/checkout/form-checkout.php
+++ b/wp-content/plugins/woo-multistep-checkout/templates/checkout/form-checkout.php
@@ -103,11 +103,10 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	$amz_cart_items = '';
 	$amz_cart_items = apply_filters( 'woozone_woo_cart_amazon_get_products', $cart);
 	$non_amz_cart_items = apply_filters('woozone_woo_cart_amazon_remove_amz_products', $cart, $amz_cart_items);
-	
 
 	?>
 
-<!--    // TODO: this is where the logic lies that changes for the 3 uses cases of the cart (amz vs elt vs amx/elt)-->
+<!--    // TODO: this is where the logic lies that changes for the 3 uses cases of the cart (amz vs elt vs amx/elt) -->
 
 	<div id="order_review" class="woocommerce-checkout-review-order">
        <?php
@@ -124,7 +123,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		}
 		?>
 
-	<?php 
+	<?php
 
 	
 	if(count($non_amz_cart_items) && count($amz_cart_items)){

--- a/wp-content/plugins/woocommerce/includes/class-wc-cart.php
+++ b/wp-content/plugins/woocommerce/includes/class-wc-cart.php
@@ -640,6 +640,8 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 
 			do_action( 'woocommerce_cart_emptied' );
+		} elseif($_had_amz_products == true) {
+			do_action('theme_set_had_amz_products_key_store', false);
 		}
 	}
 


### PR DESCRIPTION
This will fix the first attempt at checkout not subcarting the EL / AMZ use case. Basically, when checking out for the first time, the session variables don't handle the subcarting of each product respectively. However, after the first attempt, the checkout process concerning the EL / AMZ use case seems to work as expected.

**TEST**
+ Add EL product/service to cart
+ Add AMZ affiliate product to cart
+ checkout out