### PR TITLE
Fix El/Amz checkout use case to redirect after EL checkout

### DIFF
--- a/wp-content/plugins/woocommerce/includes/class-wc-cart.php
+++ b/wp-content/plugins/woocommerce/includes/class-wc-cart.php
@@ -632,8 +632,6 @@ class WC_Cart extends WC_Legacy_Cart {
 		$_had_amz_products = null;
 		$_had_amz_products = apply_filters('theme_get_key_amz_products_keys_store', $_had_amz_products);
 
-		trigger_error(sprintf($_had_amz_products));
-
 		if($_had_amz_products == false) {
 			if ( $clear_persistent_cart ) {
 				$this->session->persistent_cart_destroy();

--- a/wp-content/themes/WCM010020/functions.php
+++ b/wp-content/themes/WCM010020/functions.php
@@ -507,12 +507,12 @@ function myStartSession() {
 add_action('init', 'myStartSession', 1);
 
 function set_key_amz_product_keys_store($_amz_product_key) {
-    if(!$_SESSION['AMZ_PRODUCT_KEYS'] == null) {
+    if(!$_SESSION['AMZ_PRODUCT_KEYS']) {
 	    trigger_error("Creating AMZ PRODUCTS ARRAY");
 	    $_SESSION['AMZ_PRODUCT_KEYS'] = array();
     }
 
-    if(!$_SESSION['HAD_AMZ_PRODUCT_KEYS'] == null) {
+    if(!$_SESSION['HAD_AMZ_PRODUCT_KEYS']) {
         trigger_error('Creating AMZ key status');
 
 	    $_SESSION['HAD_AMZ_PRODUCT_KEYS'] = false;


### PR DESCRIPTION
This corrects the EL/AMZ checkout use case where the session was never created before the checkout.

**TESTING**
+ Add AMZ product to cart
+ Add EL service to cart
+ Checkout
+ Should first checkout EL service
+ Next should checkout redirect to AMZ

*Notes: Should also test AMZ only use case and EL only use case*