### PR TITLE
Remove 'report abuse' from the detailed product page

### DIFF
--- a/wp-content/plugins/dc-woocommerce-multi-vendor/classes/class-wcmp-product.php
+++ b/wp-content/plugins/dc-woocommerce-multi-vendor/classes/class-wcmp-product.php
@@ -1328,13 +1328,7 @@ class WCMp_Product {
         } else {
             $is_display = true;
         }
-
-        $report_abuse_text = $WCMp->vendor_caps->frontend_cap;
-        if (isset($report_abuse_text['report_abuse_text']) && !empty($report_abuse_text['report_abuse_text'])) {
-            $display_text = $report_abuse_text['report_abuse_text'];
-        } else {
-            $display_text = __('Report Abuse', 'dc-woocommerce-multi-vendor');
-        }
+        
         if ($is_display) {
             ?>
             <a href="#" id="report_abuse"><?php echo $display_text; ?></a><br>


### PR DESCRIPTION
This removes the "Report Abuse" on the detailed product page. Look [here](https://www.pivotaltracker.com/story/show/154447336) for more details

**TESTING**
+ Find a product detailed page
+ Notice there is not "Report Abuse" link