### PR TITLE
Remove 'Fform' from pre logged in checkout

### DIFF
--- a/wp-content/plugins/woo-multistep-checkout/templates/checkout/form-checkout.php
+++ b/wp-content/plugins/woo-multistep-checkout/templates/checkout/form-checkout.php
@@ -60,7 +60,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<li class="thwmscf-tab"><a href="javascript:void(0)" id="step-2" data-step="2"><?php echo $thwmscf_title_shipping; ?></a></li>
 		<li class="thwmscf-tab"><a href="javascript:void(0)" id="step-3" data-step="3" class="last"><?php echo $thwmscf_title_order_review; ?></a></li>
 <!--        <li class="thwmscf-tab"><a href="javascript:void(0)" id="step-4" data-step="4" class="last">--><?php //echo $thwmscf_title_test; ?><!--</a></li>-->
-	</ul>Fform
+	</ul>
 	<div id="thwmscf-tab-panels" class="thwmscf-tab-panels">
 	<?php 
 	if($enable_login_reminder){


### PR DESCRIPTION
This removes the 'Fform' in the pre-logged checkout page. (This)[https://www.pivotaltracker.com/story/show/154447336] story has more information.

**TESTING**
+ Add items to cart
+ Checkout without being logged in
+ 'Fform' should not be on the first checkout page