### PR TITLE
WC Marketplace Featured Image Fix

### DIFF
--- a/wp-content/themes/WCM010020/functions.php
+++ b/wp-content/themes/WCM010020/functions.php
@@ -6,10 +6,21 @@
  *
  * @since TemplateMela 1.0
  */
+
+define('REMOTE_STORAGE_BASE_URL', 'https://storage.googleapis.com/stateless-effortlessmarketplac');
+
 if ( ! isset( $content_width ) ) {
 	$content_width = 1150;
 }
 
+// Modify Upload BaseURL to allow Vendor Dashboard to talk to Google Cloud Storage
+if (class_exists( 'wpCloud\StatelessMedia\API' ) && is_admin() ) {
+	function emp_modify_wp_uploads_baseurl($data) {
+		$data['baseurl'] = REMOTE_STORAGE_BASE_URL;
+		return $data;
+	}
+	add_filter( 'upload_dir', 'emp_modify_wp_uploads_baseurl' );
+}
 
 function templatemela_setup() {
 	/*


### PR DESCRIPTION
This was the elegant solution I was hoping for.

WCMP has a function that resolves a Media Library url to an attachment ID.  This function assumes that the url is in the local media library, which is why it was breaking when being fed a Google Storage url.

The WCMP function was not filterable, but it makes a call to `wp_get_upload_dir` which is filterable.  I intercepted the call in `functions.php` and replaced the local `baseurl` with the Google Storage url.

Works like a champ.

I’m only overriding the `baseurl` in the event that WP Stateless is active, and the code is being called in the admin.  Should be fine to overwrite, as WP Stateless takes over any scenario that would require the Media LIbrary’s baseurl.